### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-
 # YouTube MCP Server
+[![smithery badge](https://smithery.ai/badge/@modelcontextprotocol/server-youtube)](https://smithery.ai/server/@modelcontextprotocol/server-youtube)
 A Model Context Protocol (MCP) server implementation for YouTube, enabling AI language models to interact with YouTube content through a standardized interface.
 
 ## Features
@@ -30,6 +30,15 @@ A Model Context Protocol (MCP) server implementation for YouTube, enabling AI la
 
 ## Installation
 
+### Installing via Smithery
+
+To install YouTube Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@modelcontextprotocol/server-youtube):
+
+```bash
+npx -y @smithery/cli install @modelcontextprotocol/server-youtube --client claude
+```
+
+### Manual Installation
 ```bash
 npm install @modelcontextprotocol/server-youtube
 ```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install YouTube Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@modelcontextprotocol/server-youtube

Let me know if any tweaks have to be made!