### PR TITLE
Fixed to work with Claude desktop and youtube-mcp-server as docker container

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ if (!process.env.YOUTUBE_API_KEY) {
 // Start the MCP server
 startMcpServer()
     .then(() => {
-        console.log('YouTube MCP Server started successfully');
+        console.error('YouTube MCP Server started successfully');
     })
     .catch(error => {
         console.error('Failed to start YouTube MCP Server:', error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -257,9 +257,9 @@ export async function startMcpServer() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
     
-    // Log the server info
-    console.log(`YouTube MCP Server v1.0.0 started successfully`);
-    console.log(`Server will validate YouTube API key when tools are called`);
+    // Log the server info to stderr instead of stdout
+    console.error(`YouTube MCP Server v1.0.0 started successfully`);
+    console.error(`Server will validate YouTube API key when tools are called`);
     
     return server;
 }


### PR DESCRIPTION
Hi Zubeid

i fixed this minor bug, because console output gets in the way with mcp . 
If you send the logs to error-log instead it works as a quick fix.

That my claude-desktop setup (working with the docker container under wsl):

{
  "mcpServers": {
    "youtube": {
      "command": "wsl.exe",
      "args": [
        "--shell-type","login",
        "docker",
        "run", 
        "-i", 
        "--rm",
        "-e", "YOUTUBE_API_KEY=your-secret-api-key",
        "youtube-mcp-server:latest"
      ]
    }      
  }
}