### PR TITLE
feat: add creator discovery and docker HTTP transport

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,8 +3,8 @@
 node_modules
 npm-debug.log
 Dockerfile
-.env
 .env.example
+!.env
 *.md
 !README.md
 .gitignore

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
-# YouTube API Key - Get it from https://console.cloud.google.com/apis/credentials
-YOUTUBE_API_KEY=your_api_key_here
+# YouTube API keys - get them from https://console.cloud.google.com/apis/credentials
+# The server will try key 1 first, then fail over to key 2 and key 3 on quota exhaustion.
+YOUTUBE_API_KEY=your_primary_api_key_here
+YOUTUBE_API_KEY2=your_secondary_api_key_here
+YOUTUBE_API_KEY3=your_tertiary_api_key_here
+# Optional: Default language code for transcripts (e.g., 'en', 'es', 'fr')
+# YOUTUBE_TRANSCRIPT_LANG=en

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,31 @@
-FROM node:16-alpine
+FROM node:22-alpine AS build
 
 WORKDIR /app
 
-# Copy package files first for better caching
 COPY package*.json ./
+RUN npm ci
 
-# Install dependencies
-RUN npm install
-
-# Copy application code
 COPY . .
-
-# Build the application
 RUN npm run build
 
-# Set execution permission for CLI
-RUN chmod +x dist/cli.js
+FROM node:22-alpine AS runtime
 
-# Command is provided by smithery.yaml
-CMD ["node", "dist/index.js"]
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV MCP_TRANSPORT=http
+ENV MCP_HOST=0.0.0.0
+ENV MCP_PORT=8088
+ENV MCP_STATELESS=true
+
+COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/.env ./.env
+
+EXPOSE 8088
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD node -e "fetch('http://127.0.0.1:' + (process.env.MCP_PORT || 8088) + '/ready').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+CMD ["node", "./dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -3,31 +3,87 @@
 
 A Model Context Protocol (MCP) server implementation for YouTube, enabling AI language models to interact with YouTube content through a standardized interface.
 
-## Features
+## Available Tools
 
-### Video Information
-* Get video details (title, description, duration, etc.)
-* List channel videos
-* Get video statistics (views, likes, comments)
-* Search videos across YouTube
+The server currently exposes 10 MCP tools.
 
-### Transcript Management
-* Retrieve video transcripts
-* Support for multiple languages
-* Get timestamped captions
-* Search within transcripts
+| Tool | Description | Required Parameters | Optional Parameters |
+|------|-------------|---------------------|---------------------|
+| `videos_getVideo` | Get detailed information about a YouTube video | `videoId` | `parts` |
+| `videos_searchVideos` | Search for videos on YouTube | `query` | `maxResults`, `order`, `publishedAfter`, `publishedBefore`, `channelId`, `uniqueChannels`, `channelMinSubscribers`, `channelMaxSubscribers`, `channelLastUploadAfter`, `channelLastUploadBefore`, `creatorOnly`, `sortBy` |
+| `transcripts_getTranscript` | Get the transcript of a YouTube video | `videoId` | `language` |
+| `channels_getChannel` | Get information about a YouTube channel | `channelId` | None |
+| `channels_getChannels` | Get information about multiple YouTube channels | `channelIds` | `parts`, `includeLatestUpload` |
+| `channels_searchChannels` | Search for YouTube channels by handle, name, or query | `query` | `maxResults`, `order`, `channelType`, `minSubscribers`, `maxSubscribers`, `lastUploadAfter`, `lastUploadBefore`, `creatorOnly`, `sortBy` |
+| `channels_findCreators` | Find creator channels from video mentions with channel-size and activity filters | `query` | `maxResults`, `order`, `videoPublishedAfter`, `videoPublishedBefore`, `channelMinSubscribers`, `channelMaxSubscribers`, `channelLastUploadAfter`, `channelLastUploadBefore`, `creatorOnly`, `sortBy`, `sampleVideosPerChannel` |
+| `channels_listVideos` | Get videos from a specific channel | `channelId` | `maxResults` |
+| `playlists_getPlaylist` | Get information about a YouTube playlist | `playlistId` | None |
+| `playlists_getPlaylistItems` | Get videos in a YouTube playlist | `playlistId` | `maxResults` |
 
-### Channel Management
-* Get channel details
-* List channel playlists
-* Get channel statistics
-* Search within channel content
+### Tool Parameters
 
-### Playlist Management
-* List playlist items
-* Get playlist details
-* Search within playlists
-* Get playlist video transcripts
+#### `videos_getVideo`
+- `videoId` (`string`): The YouTube video ID.
+- `parts` (`string[]`, optional): Specific video resource parts to retrieve.
+
+#### `videos_searchVideos`
+- `query` (`string`): Search query.
+- `maxResults` (`number`, optional): Maximum number of results to return.
+- `order` (`string`, optional): Result ordering such as `relevance` or `date`.
+- `publishedAfter` (`string`, optional): Only include videos published after this ISO 8601 date.
+- `publishedBefore` (`string`, optional): Only include videos published before this ISO 8601 date.
+- `channelId` (`string`, optional): Restrict results to a specific channel.
+- `uniqueChannels` (`boolean`, optional): Return only one video per unique channel.
+- `channelMinSubscribers` / `channelMaxSubscribers` (`number`, optional): Filter matched videos by the subscriber band of their channel.
+- `channelLastUploadAfter` / `channelLastUploadBefore` (`string`, optional): Filter matched videos by the latest upload activity of their channel.
+- `creatorOnly` (`boolean`, optional): Restrict results to channels heuristically classified as creators.
+- `sortBy` (`string`, optional): Supports `relevance`, `subscribers_asc`, `subscribers_desc`, `indie_priority`, and `recent_activity`.
+
+#### `transcripts_getTranscript`
+- `videoId` (`string`): The YouTube video ID.
+- `language` (`string`, optional): Transcript language code. Falls back to `YOUTUBE_TRANSCRIPT_LANG` or `en`.
+
+#### `channels_getChannel`
+- `channelId` (`string`): The YouTube channel ID.
+
+Responses now include:
+- `latestVideoPublishedAt`
+- `normalizedMetadata`
+  - includes `country`, `defaultLanguage`, `joinedAt`, `customUrl`, `emailsFound`, `contactLinks`, and creator-vs-brand heuristic fields
+
+#### `channels_getChannels`
+- `channelIds` (`string[]`): A list of YouTube channel IDs.
+- `includeLatestUpload` (`boolean`, optional): Whether to include `latestVideoPublishedAt`. Defaults to `true`.
+
+#### `channels_searchChannels`
+- `query` (`string`): Channel search query or handle.
+- `maxResults` (`number`, optional): Maximum number of channels to return.
+- `order` (`string`, optional): Result ordering such as `relevance`.
+- `channelType` (`string`, optional): Restrict the search to a channel type.
+- `minSubscribers` / `maxSubscribers` (`number`, optional): Filter channels by subscriber band.
+- `lastUploadAfter` / `lastUploadBefore` (`string`, optional): Filter channels by latest upload activity.
+- `creatorOnly` (`boolean`, optional): Restrict results to channels heuristically classified as creators.
+- `sortBy` (`string`, optional): Supports `relevance`, `subscribers_asc`, `subscribers_desc`, `indie_priority`, and `recent_activity`.
+
+#### `channels_findCreators`
+- `query` (`string`): Topic, game, or mention query to discover channels from matched videos.
+- `videoPublishedAfter` / `videoPublishedBefore` (`string`, optional): Recency filters for the matched videos.
+- `channelMinSubscribers` / `channelMaxSubscribers` (`number`, optional): Subscriber band filters for returned channels.
+- `channelLastUploadAfter` / `channelLastUploadBefore` (`string`, optional): Latest-upload activity filters for returned channels.
+- `creatorOnly` (`boolean`, optional): Restrict results to channels heuristically classified as creators.
+- `sortBy` (`string`, optional): Supports `relevance`, `subscribers_asc`, `subscribers_desc`, `indie_priority`, and `recent_activity`.
+- `sampleVideosPerChannel` (`number`, optional): How many matched videos to include per returned channel.
+
+#### `channels_listVideos`
+- `channelId` (`string`): The YouTube channel ID.
+- `maxResults` (`number`, optional): Maximum number of videos to return.
+
+#### `playlists_getPlaylist`
+- `playlistId` (`string`): The YouTube playlist ID.
+
+#### `playlists_getPlaylistItems`
+- `playlistId` (`string`): The YouTube playlist ID.
+- `maxResults` (`number`, optional): Maximum number of playlist items to return.
 
 ## Installation
 
@@ -46,7 +102,9 @@ npm install -g zubeid-youtube-mcp-server
     "zubeid-youtube-mcp-server": {
       "command": "zubeid-youtube-mcp-server",
       "env": {
-        "YOUTUBE_API_KEY": "your_youtube_api_key_here"
+        "YOUTUBE_API_KEY": "your_primary_youtube_api_key",
+        "YOUTUBE_API_KEY2": "your_secondary_youtube_api_key",
+        "YOUTUBE_API_KEY3": "your_tertiary_youtube_api_key"
       }
     }
   }
@@ -64,7 +122,9 @@ Add this to your Claude Desktop configuration:
       "command": "npx",
       "args": ["-y", "zubeid-youtube-mcp-server"],
       "env": {
-        "YOUTUBE_API_KEY": "your_youtube_api_key_here"
+        "YOUTUBE_API_KEY": "your_primary_youtube_api_key",
+        "YOUTUBE_API_KEY2": "your_secondary_youtube_api_key",
+        "YOUTUBE_API_KEY3": "your_tertiary_youtube_api_key"
       }
     }
   }
@@ -81,13 +141,18 @@ npx -y @smithery/cli install @ZubeidHendricks/youtube --client claude
 
 ## Configuration
 Set the following environment variables:
-* `YOUTUBE_API_KEY`: Your YouTube Data API key (required)
+* `YOUTUBE_API_KEY`: Primary YouTube Data API key
+* `YOUTUBE_API_KEY2`: Secondary fallback API key
+* `YOUTUBE_API_KEY3`: Third fallback API key
 * `YOUTUBE_TRANSCRIPT_LANG`: Default language for transcripts (optional, defaults to 'en')
+
+At least one of `YOUTUBE_API_KEY`, `YOUTUBE_API_KEY2`, or `YOUTUBE_API_KEY3` must be set. When a request fails because a key has exhausted its quota, the server retries the same request with the next configured key.
+
 ### Using with VS Code
 
 For one-click installation, click one of the install buttons below:
 
-[![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-NPM-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=youtube&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22zubeid-youtube-mcp-server%22%5D%2C%22env%22%3A%7B%22YOUTUBE_API_KEY%22%3A%22%24%7Binput%3AapiKey%7D%22%7D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22YouTube+API+Key%22%2C%22password%22%3Atrue%7D%5D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-NPM-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=youtube&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22zubeid-youtube-mcp-server%22%5D%2C%22env%22%3A%7B%22YOUTUBE_API_KEY%22%3A%22%24%7Binput%3AapiKey%7D%22%7D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22YouTube+API+Key%22%2C%22password%22%3Atrue%7D%5D&quality=insiders)
+[![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-NPM-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=youtube&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22zubeid-youtube-mcp-server%22%5D%2C%22env%22%3A%7B%22YOUTUBE_API_KEY%22%3A%22%24%7Binput%3AapiKey%7D%22%7D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22YouTube+API+Key%22%2C%22password%22%3Atrue%7D%5D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-NPM-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=youtube&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22zubeid-youtube-mcp-server%22%5D%2C%22env%22%3A%7B%22YOUTUBE_API_KEY%22%3A%22%24%7Binput%3AapiKey%22%7D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22YouTube+API+Key%22%2C%22password%22%3Atrue%7D%5D&quality=insiders)
 
 ### Manual Installation
 
@@ -142,65 +207,6 @@ Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace
   }
 }
 ```
-## YouTube API Setup
-1. Go to Google Cloud Console
-2. Create a new project or select an existing one
-3. Enable the YouTube Data API v3
-4. Create API credentials (API key)
-5. Copy the API key for configuration
-
-## Examples
-
-### Managing Videos
-
-```javascript
-// Get video details
-const video = await youtube.videos.getVideo({
-  videoId: "video-id"
-});
-
-// Get video transcript
-const transcript = await youtube.transcripts.getTranscript({
-  videoId: "video-id",
-  language: "en"
-});
-
-// Search videos
-const searchResults = await youtube.videos.searchVideos({
-  query: "search term",
-  maxResults: 10
-});
-```
-
-### Managing Channels
-
-```javascript
-// Get channel details
-const channel = await youtube.channels.getChannel({
-  channelId: "channel-id"
-});
-
-// List channel videos
-const videos = await youtube.channels.listVideos({
-  channelId: "channel-id",
-  maxResults: 50
-});
-```
-
-### Managing Playlists
-
-```javascript
-// Get playlist items
-const playlistItems = await youtube.playlists.getPlaylistItems({
-  playlistId: "playlist-id",
-  maxResults: 50
-});
-
-// Get playlist details
-const playlist = await youtube.playlists.getPlaylist({
-  playlistId: "playlist-id"
-});
-```
 
 ## Development
 
@@ -208,14 +214,39 @@ const playlist = await youtube.playlists.getPlaylist({
 # Install dependencies
 npm install
 
-# Run tests
-npm test
-
 # Build
 npm run build
 
-# Lint
-npm run lint
+# Start the server (requires at least one configured YouTube API key)
+npm start
+
+# Development mode with auto-rebuild
+npm run dev
+```
+
+## Docker
+
+The included Docker image starts the server over HTTP by default.
+
+- Default transport: `http`
+- Default endpoint: `http://localhost:8088/mcp`
+- Readiness endpoint: `http://localhost:8088/ready`
+- Default mode: stateless
+
+The Docker build copies `.env` into the runtime image and the server loads it automatically on startup. That means the container can run without passing API credentials at `docker run` time, as long as `.env` was present during `docker build`.
+
+```bash
+docker build -t youtube-mcp-server .
+docker run --rm -p 8088:8088 youtube-mcp-server
+```
+
+The container defaults to:
+
+```env
+MCP_TRANSPORT=http
+MCP_HOST=0.0.0.0
+MCP_PORT=8088
+MCP_STATELESS=true
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -20,15 +20,16 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.1.1",
+    "dotenv": "^17.3.1",
     "googleapis": "^129.0.0",
-    "ytdl-core": "^4.11.5",
-    "youtube-transcript": "^1.0.6"
+    "youtube-transcript": "^1.0.6",
+    "ytdl-core": "^4.11.5"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "^5.0.0",
+    "nodemon": "^3.0.0",
     "ts-node": "^10.9.1",
-    "nodemon": "^3.0.0"
+    "typescript": "^5.0.0"
   },
   "keywords": [
     "youtube",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
+import 'dotenv/config';
 import { startMcpServer } from './server.js';
+import { hasConfiguredYouTubeApiKey } from './services/youtube-client.js';
 
 // Check for required environment variables
-if (!process.env.YOUTUBE_API_KEY) {
-    console.error('Error: YOUTUBE_API_KEY environment variable is required.');
-    console.error('Please set it before running this server.');
+if (!hasConfiguredYouTubeApiKey()) {
+    console.error('Error: at least one YouTube API key is required.');
+    console.error('Set YOUTUBE_API_KEY, YOUTUBE_API_KEY2, or YOUTUBE_API_KEY3 before running this server.');
     process.exit(1);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
+import 'dotenv/config';
 import { startMcpServer } from './server.js';
+import { hasConfiguredYouTubeApiKey } from './services/youtube-client.js';
 
 // Check for required environment variables
-if (!process.env.YOUTUBE_API_KEY) {
-    console.error('Error: YOUTUBE_API_KEY environment variable is required.');
-    console.error('Please set it before running this server.');
+if (!hasConfiguredYouTubeApiKey()) {
+    console.error('Error: at least one YouTube API key is required.');
+    console.error('Set YOUTUBE_API_KEY, YOUTUBE_API_KEY2, or YOUTUBE_API_KEY3 before running this server.');
     process.exit(1);
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,8 @@
+import { createServer as createHttpServer, IncomingMessage, ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
     CallToolRequestSchema,
     ListToolsRequestSchema,
@@ -13,12 +16,53 @@ import {
     SearchParams,
     TranscriptParams,
     ChannelParams,
+    ChannelsParams,
+    ChannelSearchParams,
     ChannelVideosParams,
+    CreatorDiscoveryParams,
     PlaylistParams,
     PlaylistItemsParams,
 } from './types.js';
 
-export async function startMcpServer() {
+function safeSerialize(value: unknown, maxLength = 4000) {
+    try {
+        const serialized = JSON.stringify(value);
+        if (!serialized) {
+            return String(value);
+        }
+
+        return serialized.length > maxLength
+            ? `${serialized.slice(0, maxLength)}... [truncated ${serialized.length - maxLength} chars]`
+            : serialized;
+    } catch (error) {
+        return `[unserializable: ${error instanceof Error ? error.message : String(error)}]`;
+    }
+}
+
+function summarizeResult(result: unknown) {
+    if (Array.isArray(result)) {
+        return `array(length=${result.length})`;
+    }
+
+    if (result && typeof result === 'object') {
+        const record = result as Record<string, unknown>;
+        const keys = Object.keys(record);
+
+        if (Array.isArray(record.transcript)) {
+            return `object(keys=${keys.join(',')}; transcript=${record.transcript.length})`;
+        }
+
+        if (Array.isArray(record.timestampedTranscript)) {
+            return `object(keys=${keys.join(',')}; timestampedTranscript=${record.timestampedTranscript.length})`;
+        }
+
+        return `object(keys=${keys.join(',')})`;
+    }
+
+    return `${typeof result}(${String(result)})`;
+}
+
+function createMcpServer() {
     const server = new Server(
         {
             name: 'zubeid-youtube-mcp-server',
@@ -37,6 +81,7 @@ export async function startMcpServer() {
     const channelService = new ChannelService();
 
     server.setRequestHandler(ListToolsRequestSchema, async () => {
+        console.log('[MCP] list_tools requested');
         return {
             tools: [
                 {
@@ -74,6 +119,50 @@ export async function startMcpServer() {
                                 type: 'number',
                                 description: 'Maximum number of results to return',
                             },
+                            order: {
+                                type: 'string',
+                                description: 'Sort order for results, such as relevance or date',
+                            },
+                            publishedAfter: {
+                                type: 'string',
+                                description: 'Only include videos published after this ISO 8601 date',
+                            },
+                            publishedBefore: {
+                                type: 'string',
+                                description: 'Only include videos published before this ISO 8601 date',
+                            },
+                            channelId: {
+                                type: 'string',
+                                description: 'Restrict results to a specific channel ID',
+                            },
+                            uniqueChannels: {
+                                type: 'boolean',
+                                description: 'Return only one matched video per unique channel',
+                            },
+                            channelMinSubscribers: {
+                                type: 'number',
+                                description: 'Minimum subscriber count for the matched video channel',
+                            },
+                            channelMaxSubscribers: {
+                                type: 'number',
+                                description: 'Maximum subscriber count for the matched video channel',
+                            },
+                            channelLastUploadAfter: {
+                                type: 'string',
+                                description: 'Only include videos whose channel latest upload is after this ISO 8601 date',
+                            },
+                            channelLastUploadBefore: {
+                                type: 'string',
+                                description: 'Only include videos whose channel latest upload is before this ISO 8601 date',
+                            },
+                            creatorOnly: {
+                                type: 'boolean',
+                                description: 'Only include channels heuristically classified as creators',
+                            },
+                            sortBy: {
+                                type: 'string',
+                                description: 'Optional ranking mode such as relevance, indie_priority, subscribers_asc, subscribers_desc, or recent_activity',
+                            },
                         },
                         required: ['query'],
                     },
@@ -108,6 +197,142 @@ export async function startMcpServer() {
                             },
                         },
                         required: ['channelId'],
+                    },
+                },
+                {
+                    name: 'channels_getChannels',
+                    description: 'Get information about multiple YouTube channels',
+                    inputSchema: {
+                        type: 'object',
+                        properties: {
+                            channelIds: {
+                                type: 'array',
+                                description: 'A list of YouTube channel IDs',
+                                items: {
+                                    type: 'string',
+                                },
+                            },
+                            parts: {
+                                type: 'array',
+                                description: 'Parts of the channel resource to retrieve',
+                                items: {
+                                    type: 'string',
+                                },
+                            },
+                            includeLatestUpload: {
+                                type: 'boolean',
+                                description: 'Whether to include the latestVideoPublishedAt enrichment field',
+                            },
+                        },
+                        required: ['channelIds'],
+                    },
+                },
+                {
+                    name: 'channels_searchChannels',
+                    description: 'Search for YouTube channels by handle, name, or query',
+                    inputSchema: {
+                        type: 'object',
+                        properties: {
+                            query: {
+                                type: 'string',
+                                description: 'Channel search query or handle',
+                            },
+                            maxResults: {
+                                type: 'number',
+                                description: 'Maximum number of results to return',
+                            },
+                            order: {
+                                type: 'string',
+                                description: 'Sort order for results, such as relevance',
+                            },
+                            channelType: {
+                                type: 'string',
+                                description: 'Restrict to channel type such as any or show',
+                            },
+                            minSubscribers: {
+                                type: 'number',
+                                description: 'Minimum subscriber count for returned channels',
+                            },
+                            maxSubscribers: {
+                                type: 'number',
+                                description: 'Maximum subscriber count for returned channels',
+                            },
+                            lastUploadAfter: {
+                                type: 'string',
+                                description: 'Only include channels whose latest upload is after this ISO 8601 date',
+                            },
+                            lastUploadBefore: {
+                                type: 'string',
+                                description: 'Only include channels whose latest upload is before this ISO 8601 date',
+                            },
+                            creatorOnly: {
+                                type: 'boolean',
+                                description: 'Only include channels heuristically classified as creators',
+                            },
+                            sortBy: {
+                                type: 'string',
+                                description: 'Optional ranking mode such as relevance, indie_priority, subscribers_asc, subscribers_desc, or recent_activity',
+                            },
+                        },
+                        required: ['query'],
+                    },
+                },
+                {
+                    name: 'channels_findCreators',
+                    description: 'Find creator channels from video mentions with subscriber band and recent activity filters in one call',
+                    inputSchema: {
+                        type: 'object',
+                        properties: {
+                            query: {
+                                type: 'string',
+                                description: 'Search query such as a game name or topic mention',
+                            },
+                            maxResults: {
+                                type: 'number',
+                                description: 'Maximum number of video matches to scan before channel enrichment',
+                            },
+                            order: {
+                                type: 'string',
+                                description: 'Search ordering such as relevance or date',
+                            },
+                            videoPublishedAfter: {
+                                type: 'string',
+                                description: 'Only include matched videos published after this ISO 8601 date',
+                            },
+                            videoPublishedBefore: {
+                                type: 'string',
+                                description: 'Only include matched videos published before this ISO 8601 date',
+                            },
+                            channelMinSubscribers: {
+                                type: 'number',
+                                description: 'Minimum subscriber count for returned creator channels',
+                            },
+                            channelMaxSubscribers: {
+                                type: 'number',
+                                description: 'Maximum subscriber count for returned creator channels',
+                            },
+                            channelLastUploadAfter: {
+                                type: 'string',
+                                description: 'Only include channels whose latest upload is after this ISO 8601 date',
+                            },
+                            channelLastUploadBefore: {
+                                type: 'string',
+                                description: 'Only include channels whose latest upload is before this ISO 8601 date',
+                            },
+                            creatorOnly: {
+                                type: 'boolean',
+                                description: 'Only include channels heuristically classified as creators',
+                            },
+                            sortBy: {
+                                type: 'string',
+                                description: 'Optional ranking mode such as relevance, indie_priority, subscribers_asc, subscribers_desc, or recent_activity',
+                            },
+                            sampleVideosPerChannel: {
+                                type: 'number',
+                                description: 'How many matched video samples to include per returned channel',
+                            },
+                        },
+                        required: ['query'],
                     },
                 },
                 {
@@ -166,83 +391,62 @@ export async function startMcpServer() {
 
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const { name, arguments: args } = request.params;
+        const startedAt = Date.now();
+
+        console.log(`[MCP] tool.start name=${name} args=${safeSerialize(args)}`);
 
         try {
+            let result: unknown;
+
             switch (name) {
-                case 'videos_getVideo': {
-                    const result = await videoService.getVideo(args as unknown as VideoParams);
-                    return {
-                        content: [{
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        }]
-                    };
-                }
-                
-                case 'videos_searchVideos': {
-                    const result = await videoService.searchVideos(args as unknown as SearchParams);
-                    return {
-                        content: [{
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        }]
-                    };
-                }
-                
-                case 'transcripts_getTranscript': {
-                    const result = await transcriptService.getTranscript(args as unknown as TranscriptParams);
-                    return {
-                        content: [{
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        }]
-                    };
-                }
-                
-                case 'channels_getChannel': {
-                    const result = await channelService.getChannel(args as unknown as ChannelParams);
-                    return {
-                        content: [{
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        }]
-                    };
-                }
-                
-                case 'channels_listVideos': {
-                    const result = await channelService.listVideos(args as unknown as ChannelVideosParams);
-                    return {
-                        content: [{
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        }]
-                    };
-                }
-                
-                case 'playlists_getPlaylist': {
-                    const result = await playlistService.getPlaylist(args as unknown as PlaylistParams);
-                    return {
-                        content: [{
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        }]
-                    };
-                }
-                
-                case 'playlists_getPlaylistItems': {
-                    const result = await playlistService.getPlaylistItems(args as unknown as PlaylistItemsParams);
-                    return {
-                        content: [{
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        }]
-                    };
-                }
-                
+                case 'videos_getVideo':
+                    result = await videoService.getVideo(args as unknown as VideoParams);
+                    break;
+                case 'videos_searchVideos':
+                    result = await videoService.searchVideos(args as unknown as SearchParams);
+                    break;
+                case 'transcripts_getTranscript':
+                    result = await transcriptService.getTranscript(args as unknown as TranscriptParams);
+                    break;
+                case 'channels_getChannel':
+                    result = await channelService.getChannel(args as unknown as ChannelParams);
+                    break;
+                case 'channels_getChannels':
+                    result = await channelService.getChannels(args as unknown as ChannelsParams);
+                    break;
+                case 'channels_searchChannels':
+                    result = await channelService.searchChannels(args as unknown as ChannelSearchParams);
+                    break;
+                case 'channels_findCreators':
+                    result = await channelService.findCreators(args as unknown as CreatorDiscoveryParams);
+                    break;
+                case 'channels_listVideos':
+                    result = await channelService.listVideos(args as unknown as ChannelVideosParams);
+                    break;
+                case 'playlists_getPlaylist':
+                    result = await playlistService.getPlaylist(args as unknown as PlaylistParams);
+                    break;
+                case 'playlists_getPlaylistItems':
+                    result = await playlistService.getPlaylistItems(args as unknown as PlaylistItemsParams);
+                    break;
                 default:
                     throw new Error(`Unknown tool: ${name}`);
             }
+
+            console.log(
+                `[MCP] tool.success name=${name} durationMs=${Date.now() - startedAt} summary=${summarizeResult(result)}`
+            );
+
+            return {
+                content: [{
+                    type: 'text',
+                    text: JSON.stringify(result, null, 2)
+                }]
+            };
         } catch (error) {
+            console.error(
+                `[MCP] tool.error name=${name} durationMs=${Date.now() - startedAt} error=${error instanceof Error ? error.stack || error.message : String(error)}`
+            );
             return {
                 content: [{
                     type: 'text',
@@ -253,13 +457,150 @@ export async function startMcpServer() {
         }
     });
 
-    // Create transport and connect
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
-    
-    // Log the server info
-    console.log(`YouTube MCP Server v1.0.0 started successfully`);
-    console.log(`Server will validate YouTube API key when tools are called`);
-    
     return server;
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+    const chunks: Buffer[] = [];
+
+    for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+
+    if (chunks.length === 0) {
+        return undefined;
+    }
+
+    const raw = Buffer.concat(chunks).toString('utf8').trim();
+
+    if (!raw) {
+        return undefined;
+    }
+
+    return JSON.parse(raw);
+}
+
+function writeJson(res: ServerResponse, statusCode: number, payload: unknown) {
+    res.statusCode = statusCode;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(payload));
+}
+
+async function startStdioServer() {
+    const server = createMcpServer();
+    const transport = new StdioServerTransport();
+
+    await server.connect(transport);
+
+    console.log('YouTube MCP Server v1.0.0 started successfully over stdio');
+    console.log('Server will validate YouTube API key when tools are called');
+
+    return server;
+}
+
+async function startHttpMcpServer() {
+    const host = process.env.MCP_HOST || '0.0.0.0';
+    const port = Number(process.env.MCP_PORT || '8088');
+    const stateless = process.env.MCP_STATELESS !== 'false';
+
+    const httpServer = createHttpServer(async (req, res) => {
+        const requestStartedAt = Date.now();
+        const origin = `http://${req.headers.host || `${host}:${port}`}`;
+        const url = new URL(req.url || '/', origin);
+
+        res.on('finish', () => {
+            console.log(
+                `[HTTP] ${req.method} ${url.pathname} status=${res.statusCode} durationMs=${Date.now() - requestStartedAt}`
+            );
+        });
+
+        if (url.pathname === '/ready') {
+            writeJson(res, 200, {
+                status: 'ok',
+                transport: 'http',
+                stateless,
+            });
+            return;
+        }
+
+        if (url.pathname !== '/mcp') {
+            writeJson(res, 404, {
+                error: 'Not found',
+            });
+            return;
+        }
+
+        let parsedBody: unknown;
+
+        if (req.method === 'POST') {
+            try {
+                parsedBody = await readJsonBody(req);
+                console.log(`[HTTP] request.body method=${req.method} path=${url.pathname} body=${safeSerialize(parsedBody)}`);
+            } catch (error) {
+                writeJson(res, 400, {
+                    jsonrpc: '2.0',
+                    error: {
+                        code: -32700,
+                        message: `Invalid JSON body: ${error instanceof Error ? error.message : String(error)}`,
+                    },
+                    id: null,
+                });
+                return;
+            }
+        }
+
+        const server = createMcpServer();
+        const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: stateless ? undefined : () => randomUUID(),
+            enableJsonResponse: stateless,
+        });
+
+        res.on('close', () => {
+            transport.close().catch(() => undefined);
+            server.close().catch(() => undefined);
+        });
+
+        try {
+            await server.connect(transport);
+            await transport.handleRequest(req, res, parsedBody);
+        } catch (error) {
+            console.error('Error handling HTTP MCP request:', error);
+
+            if (!res.headersSent) {
+                writeJson(res, 500, {
+                    jsonrpc: '2.0',
+                    error: {
+                        code: -32603,
+                        message: error instanceof Error ? error.message : 'Internal server error',
+                    },
+                    id: null,
+                });
+            }
+        }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        httpServer.once('error', reject);
+        httpServer.listen(port, host, () => {
+            httpServer.off('error', reject);
+            resolve();
+        });
+    });
+
+    console.log('YouTube MCP Server v1.0.0 started successfully over HTTP');
+    console.log(`Listening on http://${host}:${port}/mcp`);
+    console.log(`Readiness endpoint available at http://${host}:${port}/ready`);
+    console.log('Server will validate YouTube API key when tools are called');
+
+    return httpServer;
+}
+
+export async function startMcpServer() {
+    const transport = (process.env.MCP_TRANSPORT || 'stdio').toLowerCase();
+
+    if (transport === 'http') {
+        return startHttpMcpServer();
+    }
+
+    return startStdioServer();
 }

--- a/src/services/channel-metadata.ts
+++ b/src/services/channel-metadata.ts
@@ -1,0 +1,164 @@
+const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const URL_REGEX = /\bhttps?:\/\/[^\s<>"')]+/gi;
+
+const BRAND_KEYWORDS = [
+  'official',
+  'records',
+  'vevo',
+  'music',
+  'news',
+  'network',
+  'media',
+  'trailer',
+  'trailers',
+  'studio',
+  'studios',
+  'tv',
+  'television',
+  'clips',
+  'highlights',
+  'publisher',
+  'developer',
+  'esports',
+  'radio',
+  'topic',
+];
+
+const CREATOR_KEYWORDS = [
+  'i play',
+  'my channel',
+  'my videos',
+  'my content',
+  'i upload',
+  'let\'s play',
+  'lets play',
+  'streamer',
+  'content creator',
+  'creator',
+  'reviewer',
+];
+
+function uniq(values: string[]) {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function toNumber(value: unknown) {
+  const parsed = Number(value || 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function extractEmails(text?: string | null) {
+  return uniq((text || '').match(EMAIL_REGEX) || []);
+}
+
+export function extractContactLinks(text?: string | null) {
+  return uniq((text || '').match(URL_REGEX) || []);
+}
+
+export function buildChannelUrl(channelId?: string | null, customUrl?: string | null) {
+  if (customUrl) {
+    return `https://www.youtube.com/${customUrl}`;
+  }
+
+  return channelId ? `https://www.youtube.com/channel/${channelId}` : null;
+}
+
+export function classifyChannel(channel: any) {
+  const title = String(channel?.snippet?.title || '').toLowerCase();
+  const description = String(
+    channel?.brandingSettings?.channel?.description ||
+    channel?.snippet?.description ||
+    ''
+  ).toLowerCase();
+  const text = `${title} ${description}`;
+
+  const matchedBrandKeywords = BRAND_KEYWORDS.filter((keyword) => text.includes(keyword));
+  const matchedCreatorKeywords = CREATOR_KEYWORDS.filter((keyword) => text.includes(keyword));
+
+  let channelTypeHeuristic: 'creator' | 'brand_or_media' | 'unknown' = 'unknown';
+
+  if (matchedBrandKeywords.length >= 2 && matchedBrandKeywords.length > matchedCreatorKeywords.length) {
+    channelTypeHeuristic = 'brand_or_media';
+  } else if (matchedCreatorKeywords.length > 0 && matchedCreatorKeywords.length >= matchedBrandKeywords.length) {
+    channelTypeHeuristic = 'creator';
+  }
+
+  return {
+    channelTypeHeuristic,
+    brandKeywordHits: matchedBrandKeywords,
+    creatorKeywordHits: matchedCreatorKeywords,
+    heuristicConfidence: Math.max(matchedBrandKeywords.length, matchedCreatorKeywords.length),
+  };
+}
+
+export function normalizeChannel(channel: any, latestVideoPublishedAt?: string | null) {
+  const snippet = channel?.snippet || {};
+  const statistics = channel?.statistics || {};
+  const branding = channel?.brandingSettings?.channel || {};
+  const description = branding.description || snippet.description || '';
+  const customUrl = snippet.customUrl || null;
+  const channelId = channel?.id || null;
+  const emailsFound = extractEmails(description);
+  const contactLinks = extractContactLinks(description);
+  const heuristic = classifyChannel(channel);
+
+  return {
+    ...channel,
+    latestVideoPublishedAt: latestVideoPublishedAt || null,
+    normalizedMetadata: {
+      channelId,
+      title: snippet.title || null,
+      description,
+      customUrl,
+      url: buildChannelUrl(channelId, customUrl),
+      country: branding.country || snippet.country || null,
+      defaultLanguage: branding.defaultLanguage || snippet.defaultLanguage || null,
+      joinedAt: snippet.publishedAt || null,
+      uploadsPlaylistId: channel?.contentDetails?.relatedPlaylists?.uploads || null,
+      subscriberCount: toNumber(statistics.subscriberCount),
+      videoCount: toNumber(statistics.videoCount),
+      viewCount: toNumber(statistics.viewCount),
+      emailsFound,
+      contactLinks,
+      businessEmail: null,
+      contactExtractionNote: 'YouTube Data API does not expose business email. Emails and links are parsed from channel description only.',
+      ...heuristic,
+    },
+  };
+}
+
+export function isAfter(dateValue?: string | null, threshold?: string | null) {
+  if (!threshold) {
+    return true;
+  }
+
+  if (!dateValue) {
+    return false;
+  }
+
+  return new Date(dateValue).getTime() >= new Date(threshold).getTime();
+}
+
+export function isBefore(dateValue?: string | null, threshold?: string | null) {
+  if (!threshold) {
+    return true;
+  }
+
+  if (!dateValue) {
+    return false;
+  }
+
+  return new Date(dateValue).getTime() <= new Date(threshold).getTime();
+}
+
+export function inSubscriberRange(subscriberCount: number, minSubscribers?: number, maxSubscribers?: number) {
+  if (typeof minSubscribers === 'number' && subscriberCount < minSubscribers) {
+    return false;
+  }
+
+  if (typeof maxSubscribers === 'number' && subscriberCount > maxSubscribers) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/services/channel.ts
+++ b/src/services/channel.ts
@@ -1,71 +1,301 @@
-import { google } from 'googleapis';
-import { ChannelParams, ChannelVideosParams } from '../types.js';
+import { withYouTubeClient } from './youtube-client.js';
+import { buildChannelUrl, inSubscriberRange, isAfter, isBefore, normalizeChannel } from './channel-metadata.js';
+import {
+  ChannelParams,
+  ChannelSearchParams,
+  ChannelsParams,
+  ChannelVideosParams,
+  CreatorDiscoveryParams,
+} from '../types.js';
+
+type EnrichedChannel = any;
 
 /**
  * Service for interacting with YouTube channels
  */
 export class ChannelService {
-  private youtube;
-  private initialized = false;
-
-  constructor() {
-    // Don't initialize in constructor
-  }
-
-  /**
-   * Initialize the YouTube client only when needed
-   */
-  private initialize() {
-    if (this.initialized) return;
-    
-    const apiKey = process.env.YOUTUBE_API_KEY;
-    if (!apiKey) {
-      throw new Error('YOUTUBE_API_KEY environment variable is not set.');
+  private async fetchRawChannels(channelIds: string[], parts = ['snippet', 'statistics', 'contentDetails', 'brandingSettings']) {
+    if (channelIds.length === 0) {
+      return [];
     }
 
-    this.youtube = google.youtube({
-      version: 'v3',
-      auth: apiKey
+    const response = await withYouTubeClient((youtube) => youtube.channels.list({
+      part: parts,
+      id: channelIds
+    }));
+
+    return response.data.items || [];
+  }
+
+  private async getLatestVideoPublishedAt(channelId: string): Promise<string | null> {
+    try {
+      const response = await withYouTubeClient((youtube) => youtube.search.list({
+        part: ['snippet'],
+        channelId,
+        maxResults: 1,
+        order: 'date',
+        type: ['video']
+      }));
+
+      return response.data.items?.[0]?.snippet?.publishedAt || null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async getLatestVideoPublishedAtMap(channelIds: string[]) {
+    const entries = await Promise.all(
+      channelIds.map(async (channelId) => [channelId, await this.getLatestVideoPublishedAt(channelId)] as const)
+    );
+
+    return Object.fromEntries(entries);
+  }
+
+  private filterEnrichedChannels(channels: EnrichedChannel[], filters: {
+    minSubscribers?: number;
+    maxSubscribers?: number;
+    lastUploadAfter?: string;
+    lastUploadBefore?: string;
+    creatorOnly?: boolean;
+  }) {
+    return channels.filter((channel) => {
+      const metadata = channel.normalizedMetadata || {};
+
+      if (!inSubscriberRange(metadata.subscriberCount || 0, filters.minSubscribers, filters.maxSubscribers)) {
+        return false;
+      }
+
+      if (!isAfter(channel.latestVideoPublishedAt, filters.lastUploadAfter)) {
+        return false;
+      }
+
+      if (!isBefore(channel.latestVideoPublishedAt, filters.lastUploadBefore)) {
+        return false;
+      }
+
+      if (filters.creatorOnly && metadata.channelTypeHeuristic !== 'creator') {
+        return false;
+      }
+
+      return true;
     });
-    
-    this.initialized = true;
+  }
+
+  private sortEnrichedChannels(channels: EnrichedChannel[], sortBy = 'relevance', searchRankMap?: Record<string, number>) {
+    const ranked = [...channels];
+
+    ranked.sort((left, right) => {
+      const leftMeta = left.normalizedMetadata || {};
+      const rightMeta = right.normalizedMetadata || {};
+      const leftRank = searchRankMap?.[left.id] ?? Number.MAX_SAFE_INTEGER;
+      const rightRank = searchRankMap?.[right.id] ?? Number.MAX_SAFE_INTEGER;
+
+      switch (sortBy) {
+        case 'subscribers_asc':
+          return (leftMeta.subscriberCount || 0) - (rightMeta.subscriberCount || 0) || leftRank - rightRank;
+        case 'subscribers_desc':
+          return (rightMeta.subscriberCount || 0) - (leftMeta.subscriberCount || 0) || leftRank - rightRank;
+        case 'recent_activity':
+          return new Date(right.latestVideoPublishedAt || 0).getTime() - new Date(left.latestVideoPublishedAt || 0).getTime() || leftRank - rightRank;
+        case 'indie_priority':
+          return (leftMeta.subscriberCount || 0) - (rightMeta.subscriberCount || 0) || leftRank - rightRank;
+        case 'relevance':
+        default:
+          return leftRank - rightRank;
+      }
+    });
+
+    return ranked;
+  }
+
+  async enrichChannels({
+    channelIds,
+    includeLatestUpload = true
+  }: ChannelsParams): Promise<any[]> {
+    try {
+      const rawChannels = await this.fetchRawChannels(channelIds);
+      const latestMap = includeLatestUpload
+        ? await this.getLatestVideoPublishedAtMap(rawChannels.map((channel) => channel.id))
+        : {};
+
+      return rawChannels.map((channel) => normalizeChannel(channel, latestMap[channel.id] || null));
+    } catch (error) {
+      throw new Error(`Failed to enrich channels: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   /**
    * Get channel details
    */
-  async getChannel({ 
-    channelId 
+  async getChannel({
+    channelId
   }: ChannelParams): Promise<any> {
+    const channels = await this.enrichChannels({
+      channelIds: [channelId],
+      includeLatestUpload: true
+    });
+
+    return channels[0] || null;
+  }
+
+  /**
+   * Get details for multiple channels in one request
+   */
+  async getChannels({
+    channelIds,
+    includeLatestUpload = true
+  }: ChannelsParams): Promise<any[]> {
+    return this.enrichChannels({
+      channelIds,
+      includeLatestUpload
+    });
+  }
+
+  /**
+   * Search for YouTube channels by handle, name, or query and enrich them
+   */
+  async searchChannels({
+    query,
+    maxResults = 5,
+    order = 'relevance',
+    channelType,
+    minSubscribers,
+    maxSubscribers,
+    lastUploadAfter,
+    lastUploadBefore,
+    creatorOnly = false,
+    sortBy = 'relevance'
+  }: ChannelSearchParams): Promise<any[]> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.channels.list({
-        part: ['snippet', 'statistics', 'contentDetails'],
-        id: [channelId]
+      const params: any = {
+        part: ['snippet'],
+        q: query,
+        maxResults,
+        order,
+        type: ['channel']
+      };
+
+      if (channelType) {
+        params.channelType = channelType;
+      }
+
+      const response = await withYouTubeClient((youtube) => youtube.search.list(params));
+      const items = response.data.items || [];
+      const searchRankMap = Object.fromEntries(items.map((item, index) => [item.snippet?.channelId, index]));
+      const enriched = await this.enrichChannels({
+        channelIds: items.map((item) => item.snippet?.channelId).filter(Boolean),
+        includeLatestUpload: true
+      });
+      const filtered = this.filterEnrichedChannels(enriched, {
+        minSubscribers,
+        maxSubscribers,
+        lastUploadAfter,
+        lastUploadBefore,
+        creatorOnly,
       });
 
-      return response.data.items?.[0] || null;
+      return this.sortEnrichedChannels(filtered, sortBy, searchRankMap);
     } catch (error) {
-      throw new Error(`Failed to get channel: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(`Failed to search channels: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Discover creator channels from video mentions in one endpoint
+   */
+  async findCreators({
+    query,
+    maxResults = 10,
+    order = 'relevance',
+    videoPublishedAfter,
+    videoPublishedBefore,
+    channelMinSubscribers,
+    channelMaxSubscribers,
+    channelLastUploadAfter,
+    channelLastUploadBefore,
+    creatorOnly = false,
+    sortBy = 'relevance',
+    sampleVideosPerChannel = 3,
+  }: CreatorDiscoveryParams): Promise<any[]> {
+    try {
+      const searchParams: any = {
+        part: ['snippet'],
+        q: query,
+        maxResults,
+        order,
+        type: ['video']
+      };
+
+      if (videoPublishedAfter) {
+        searchParams.publishedAfter = videoPublishedAfter;
+      }
+
+      if (videoPublishedBefore) {
+        searchParams.publishedBefore = videoPublishedBefore;
+      }
+
+      const response = await withYouTubeClient((youtube) => youtube.search.list(searchParams));
+      const videos = response.data.items || [];
+      const videosByChannel = new Map<string, any[]>();
+      const channelOrder = new Map<string, number>();
+
+      for (const [index, item] of videos.entries()) {
+        const channelId = item?.snippet?.channelId;
+        if (!channelId) {
+          continue;
+        }
+
+        if (!videosByChannel.has(channelId)) {
+          videosByChannel.set(channelId, []);
+          channelOrder.set(channelId, index);
+        }
+
+        videosByChannel.get(channelId)?.push(item);
+      }
+
+      const enriched = await this.enrichChannels({
+        channelIds: Array.from(videosByChannel.keys()),
+        includeLatestUpload: true
+      });
+      const filtered = this.filterEnrichedChannels(enriched, {
+        minSubscribers: channelMinSubscribers,
+        maxSubscribers: channelMaxSubscribers,
+        lastUploadAfter: channelLastUploadAfter,
+        lastUploadBefore: channelLastUploadBefore,
+        creatorOnly,
+      });
+      const sorted = this.sortEnrichedChannels(filtered, sortBy, Object.fromEntries(channelOrder.entries()));
+
+      return sorted.map((channel) => ({
+        ...channel,
+        matchedQuery: query,
+        matchCount: videosByChannel.get(channel.id)?.length || 0,
+        matchedVideos: (videosByChannel.get(channel.id) || []).slice(0, sampleVideosPerChannel).map((item) => ({
+          videoId: item.id?.videoId || null,
+          title: item.snippet?.title || null,
+          description: item.snippet?.description || null,
+          publishedAt: item.snippet?.publishedAt || null,
+          channelTitle: item.snippet?.channelTitle || null,
+        })),
+      }));
+    } catch (error) {
+      throw new Error(`Failed to find creators: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
   /**
    * Get channel playlists
    */
-  async getPlaylists({ 
-    channelId, 
-    maxResults = 50 
+  async getPlaylists({
+    channelId,
+    maxResults = 50
   }: ChannelVideosParams): Promise<any[]> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.playlists.list({
+      const response = await withYouTubeClient((youtube) => youtube.playlists.list({
         part: ['snippet', 'contentDetails'],
         channelId,
         maxResults
-      });
+      }));
 
       return response.data.items || [];
     } catch (error) {
@@ -76,20 +306,18 @@ export class ChannelService {
   /**
    * Get channel videos
    */
-  async listVideos({ 
-    channelId, 
-    maxResults = 50 
+  async listVideos({
+    channelId,
+    maxResults = 50
   }: ChannelVideosParams): Promise<any[]> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.search.list({
+      const response = await withYouTubeClient((youtube) => youtube.search.list({
         part: ['snippet'],
         channelId,
         maxResults,
         order: 'date',
         type: ['video']
-      });
+      }));
 
       return response.data.items || [];
     } catch (error) {
@@ -100,18 +328,12 @@ export class ChannelService {
   /**
    * Get channel statistics
    */
-  async getStatistics({ 
-    channelId 
+  async getStatistics({
+    channelId
   }: ChannelParams): Promise<any> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.channels.list({
-        part: ['statistics'],
-        id: [channelId]
-      });
-
-      return response.data.items?.[0]?.statistics || null;
+      const channel = await this.getChannel({ channelId });
+      return channel?.statistics || null;
     } catch (error) {
       throw new Error(`Failed to get channel statistics: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/src/services/playlist.ts
+++ b/src/services/playlist.ts
@@ -1,36 +1,10 @@
-import { google } from 'googleapis';
 import { PlaylistParams, PlaylistItemsParams, SearchParams } from '../types.js';
+import { withYouTubeClient } from './youtube-client.js';
 
 /**
  * Service for interacting with YouTube playlists
  */
 export class PlaylistService {
-  private youtube;
-  private initialized = false;
-
-  constructor() {
-    // Don't initialize in constructor
-  }
-
-  /**
-   * Initialize the YouTube client only when needed
-   */
-  private initialize() {
-    if (this.initialized) return;
-    
-    const apiKey = process.env.YOUTUBE_API_KEY;
-    if (!apiKey) {
-      throw new Error('YOUTUBE_API_KEY environment variable is not set.');
-    }
-
-    this.youtube = google.youtube({
-      version: "v3",
-      auth: apiKey
-    });
-    
-    this.initialized = true;
-  }
-
   /**
    * Get information about a YouTube playlist
    */
@@ -38,12 +12,10 @@ export class PlaylistService {
     playlistId 
   }: PlaylistParams): Promise<any> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.playlists.list({
+      const response = await withYouTubeClient((youtube) => youtube.playlists.list({
         part: ['snippet', 'contentDetails'],
         id: [playlistId]
-      });
+      }));
       
       return response.data.items?.[0] || null;
     } catch (error) {
@@ -59,13 +31,11 @@ export class PlaylistService {
     maxResults = 50 
   }: PlaylistItemsParams): Promise<any[]> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.playlistItems.list({
+      const response = await withYouTubeClient((youtube) => youtube.playlistItems.list({
         part: ['snippet', 'contentDetails'],
         playlistId,
         maxResults
-      });
+      }));
       
       return response.data.items || [];
     } catch (error) {
@@ -81,14 +51,12 @@ export class PlaylistService {
     maxResults = 10 
   }: SearchParams): Promise<any[]> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.search.list({
+      const response = await withYouTubeClient((youtube) => youtube.search.list({
         part: ['snippet'],
         q: query,
         maxResults,
         type: ['playlist']
-      });
+      }));
       
       return response.data.items || [];
     } catch (error) {

--- a/src/services/video.ts
+++ b/src/services/video.ts
@@ -1,35 +1,12 @@
-import { google } from 'googleapis';
 import { VideoParams, SearchParams, TrendingParams, RelatedVideosParams } from '../types.js';
+import { withYouTubeClient } from './youtube-client.js';
+import { ChannelService } from './channel.js';
 
 /**
  * Service for interacting with YouTube videos
  */
 export class VideoService {
-  private youtube;
-  private initialized = false;
-
-  constructor() {
-    // Don't initialize in constructor
-  }
-
-  /**
-   * Initialize the YouTube client only when needed
-   */
-  private initialize() {
-    if (this.initialized) return;
-    
-    const apiKey = process.env.YOUTUBE_API_KEY;
-    if (!apiKey) {
-      throw new Error('YOUTUBE_API_KEY environment variable is not set.');
-    }
-
-    this.youtube = google.youtube({
-      version: 'v3',
-      auth: apiKey
-    });
-    
-    this.initialized = true;
-  }
+  private channelService = new ChannelService();
 
   /**
    * Get detailed information about a YouTube video
@@ -39,12 +16,10 @@ export class VideoService {
     parts = ['snippet', 'contentDetails', 'statistics'] 
   }: VideoParams): Promise<any> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.videos.list({
+      const response = await withYouTubeClient((youtube) => youtube.videos.list({
         part: parts,
         id: [videoId]
-      });
+      }));
       
       return response.data.items?.[0] || null;
     } catch (error) {
@@ -57,19 +32,123 @@ export class VideoService {
    */
   async searchVideos({ 
     query, 
-    maxResults = 10 
+    maxResults = 10,
+    order = 'relevance',
+    publishedAfter,
+    publishedBefore,
+    channelId,
+    uniqueChannels = false,
+    channelMinSubscribers,
+    channelMaxSubscribers,
+    channelLastUploadAfter,
+    channelLastUploadBefore,
+    creatorOnly = false,
+    sortBy = 'relevance'
   }: SearchParams): Promise<any[]> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.search.list({
+      const params: any = {
         part: ['snippet'],
         q: query,
         maxResults,
+        order,
         type: ['video']
+      };
+
+      if (publishedAfter) {
+        params.publishedAfter = publishedAfter;
+      }
+
+      if (publishedBefore) {
+        params.publishedBefore = publishedBefore;
+      }
+
+      if (channelId) {
+        params.channelId = channelId;
+      }
+
+      const response = await withYouTubeClient((youtube) => youtube.search.list(params));
+      let items: any[] = response.data.items || [];
+
+      const needsChannelFiltering =
+        uniqueChannels ||
+        creatorOnly ||
+        typeof channelMinSubscribers === 'number' ||
+        typeof channelMaxSubscribers === 'number' ||
+        Boolean(channelLastUploadAfter) ||
+        Boolean(channelLastUploadBefore) ||
+        sortBy !== 'relevance';
+
+      if (!needsChannelFiltering) {
+        return items;
+      }
+
+      const uniqueChannelIds = Array.from(new Set(
+        items.map((item) => item?.snippet?.channelId).filter(Boolean)
+      ));
+
+      const enrichedChannels = await this.channelService.getChannels({
+        channelIds: uniqueChannelIds,
+        includeLatestUpload: true
       });
-      
-      return response.data.items || [];
+      const channelMap = new Map(enrichedChannels.map((channel) => [channel.id, channel]));
+
+      items = items.filter((item) => {
+        const channel = channelMap.get(item?.snippet?.channelId);
+        const metadata = channel?.normalizedMetadata;
+
+        if (!channel || !metadata) {
+          return false;
+        }
+
+        if (typeof channelMinSubscribers === 'number' && metadata.subscriberCount < channelMinSubscribers) {
+          return false;
+        }
+
+        if (typeof channelMaxSubscribers === 'number' && metadata.subscriberCount > channelMaxSubscribers) {
+          return false;
+        }
+
+        if (channelLastUploadAfter && (!channel.latestVideoPublishedAt || new Date(channel.latestVideoPublishedAt).getTime() < new Date(channelLastUploadAfter).getTime())) {
+          return false;
+        }
+
+        if (channelLastUploadBefore && (!channel.latestVideoPublishedAt || new Date(channel.latestVideoPublishedAt).getTime() > new Date(channelLastUploadBefore).getTime())) {
+          return false;
+        }
+
+        if (creatorOnly && metadata.channelTypeHeuristic !== 'creator') {
+          return false;
+        }
+
+        return true;
+      }).map((item) => ({
+        ...item,
+        channelMetadata: channelMap.get(item?.snippet?.channelId)?.normalizedMetadata || null,
+        latestChannelUploadAt: channelMap.get(item?.snippet?.channelId)?.latestVideoPublishedAt || null,
+      }));
+
+      if (uniqueChannels) {
+        const seenChannelIds = new Set<string>();
+        items = items.filter((item) => {
+          const currentChannelId = item?.snippet?.channelId;
+          if (!currentChannelId || seenChannelIds.has(currentChannelId)) {
+            return false;
+          }
+
+          seenChannelIds.add(currentChannelId);
+          return true;
+        });
+      }
+
+      if (sortBy === 'subscribers_asc' || sortBy === 'indie_priority') {
+        items.sort((left, right) => (left.channelMetadata?.subscriberCount || 0) - (right.channelMetadata?.subscriberCount || 0));
+      } else if (sortBy === 'subscribers_desc') {
+        items.sort((left, right) => (right.channelMetadata?.subscriberCount || 0) - (left.channelMetadata?.subscriberCount || 0));
+      } else if (sortBy === 'recent_activity') {
+        items.sort((left, right) => new Date(right.latestChannelUploadAt || 0).getTime() - new Date(left.latestChannelUploadAt || 0).getTime());
+      }
+
+      return items;
     } catch (error) {
       throw new Error(`Failed to search videos: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -82,12 +161,10 @@ export class VideoService {
     videoId 
   }: { videoId: string }): Promise<any> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.videos.list({
+      const response = await withYouTubeClient((youtube) => youtube.videos.list({
         part: ['statistics'],
         id: [videoId]
-      });
+      }));
       
       return response.data.items?.[0]?.statistics || null;
     } catch (error) {
@@ -104,8 +181,6 @@ export class VideoService {
     videoCategoryId = ''
   }: TrendingParams): Promise<any[]> {
     try {
-      this.initialize();
-      
       const params: any = {
         part: ['snippet', 'contentDetails', 'statistics'],
         chart: 'mostPopular',
@@ -117,7 +192,7 @@ export class VideoService {
         params.videoCategoryId = videoCategoryId;
       }
       
-      const response = await this.youtube.videos.list(params);
+      const response = await withYouTubeClient((youtube) => youtube.videos.list(params));
       
       return response.data.items || [];
     } catch (error) {
@@ -133,14 +208,14 @@ export class VideoService {
     maxResults = 10 
   }: RelatedVideosParams): Promise<any[]> {
     try {
-      this.initialize();
-      
-      const response = await this.youtube.search.list({
+      const params: any = {
         part: ['snippet'],
         relatedToVideoId: videoId,
         maxResults,
         type: ['video']
-      });
+      };
+
+      const response = await withYouTubeClient((youtube) => youtube.search.list(params));
       
       return response.data.items || [];
     } catch (error) {

--- a/src/services/youtube-client.ts
+++ b/src/services/youtube-client.ts
@@ -1,0 +1,118 @@
+import { google } from 'googleapis';
+
+type YouTubeClient = ReturnType<typeof google.youtube>;
+
+const QUOTA_ERROR_REASONS = new Set([
+  'quotaExceeded',
+  'dailyLimitExceeded',
+  'dailyLimitExceededExceeded',
+  'userRateLimitExceeded',
+  'rateLimitExceeded',
+]);
+
+class YouTubeClientPool {
+  private clients: YouTubeClient[] = [];
+  private exhaustedClientIndexes = new Set<number>();
+  private initialized = false;
+
+  private initialize() {
+    if (this.initialized) {
+      return;
+    }
+
+    const apiKeys = [
+      process.env.YOUTUBE_API_KEY,
+      process.env.YOUTUBE_API_KEY2,
+      process.env.YOUTUBE_API_KEY3,
+    ].filter((value): value is string => Boolean(value && value.trim()));
+
+    if (apiKeys.length === 0) {
+      throw new Error(
+        'At least one YouTube API key must be set. Supported env vars: YOUTUBE_API_KEY, YOUTUBE_API_KEY2, YOUTUBE_API_KEY3.'
+      );
+    }
+
+    this.clients = apiKeys.map((apiKey) =>
+      google.youtube({
+        version: 'v3',
+        auth: apiKey,
+      })
+    );
+
+    this.initialized = true;
+  }
+
+  private isQuotaError(error: any): boolean {
+    const reasons =
+      error?.errors?.map((item: any) => item?.reason).filter(Boolean) ||
+      error?.response?.data?.error?.errors?.map((item: any) => item?.reason).filter(Boolean) ||
+      [];
+
+    if (reasons.some((reason: string) => QUOTA_ERROR_REASONS.has(reason))) {
+      return true;
+    }
+
+    const message = String(
+      error?.message ||
+      error?.response?.data?.error?.message ||
+      ''
+    ).toLowerCase();
+
+    return (
+      message.includes('quota') ||
+      message.includes('daily limit') ||
+      message.includes('rate limit')
+    );
+  }
+
+  private availableClientIndexes(): number[] {
+    const available = this.clients
+      .map((_, index) => index)
+      .filter((index) => !this.exhaustedClientIndexes.has(index));
+
+    return available.length > 0
+      ? available
+      : this.clients.map((_, index) => index);
+  }
+
+  async execute<T>(request: (youtube: YouTubeClient) => Promise<T>): Promise<T> {
+    this.initialize();
+
+    let lastError: unknown;
+    const candidates = this.availableClientIndexes();
+
+    for (const index of candidates) {
+      try {
+        return await request(this.clients[index]);
+      } catch (error) {
+        lastError = error;
+
+        if (this.isQuotaError(error)) {
+          this.exhaustedClientIndexes.add(index);
+          console.warn(`YouTube API quota exhausted for key ${index + 1}. Trying next configured key.`);
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    throw new Error(
+      `All configured YouTube API keys failed${lastError instanceof Error ? `: ${lastError.message}` : '.'}`
+    );
+  }
+}
+
+const pool = new YouTubeClientPool();
+
+export function hasConfiguredYouTubeApiKey(): boolean {
+  return Boolean(
+    process.env.YOUTUBE_API_KEY ||
+    process.env.YOUTUBE_API_KEY2 ||
+    process.env.YOUTUBE_API_KEY3
+  );
+}
+
+export async function withYouTubeClient<T>(request: (youtube: YouTubeClient) => Promise<T>): Promise<T> {
+  return pool.execute(request);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,17 @@ export interface VideoParams {
 export interface SearchParams {
   query: string;
   maxResults?: number;
+  order?: string;
+  publishedAfter?: string;
+  publishedBefore?: string;
+  channelId?: string;
+  uniqueChannels?: boolean;
+  channelMinSubscribers?: number;
+  channelMaxSubscribers?: number;
+  channelLastUploadAfter?: string;
+  channelLastUploadBefore?: string;
+  creatorOnly?: boolean;
+  sortBy?: 'relevance' | 'date' | 'subscribers_asc' | 'subscribers_desc' | 'indie_priority' | 'recent_activity';
 }
 
 /**
@@ -53,6 +64,49 @@ export interface SearchTranscriptParams {
  */
 export interface ChannelParams {
   channelId: string;
+}
+
+/**
+ * Channel lookup parameters
+ */
+export interface ChannelsParams {
+  channelIds: string[];
+  parts?: string[];
+  includeLatestUpload?: boolean;
+}
+
+/**
+ * Channel search parameters
+ */
+export interface ChannelSearchParams {
+  query: string;
+  maxResults?: number;
+  order?: string;
+  channelType?: string;
+  minSubscribers?: number;
+  maxSubscribers?: number;
+  lastUploadAfter?: string;
+  lastUploadBefore?: string;
+  creatorOnly?: boolean;
+  sortBy?: 'relevance' | 'subscribers_asc' | 'subscribers_desc' | 'indie_priority' | 'recent_activity';
+}
+
+/**
+ * Creator discovery parameters
+ */
+export interface CreatorDiscoveryParams {
+  query: string;
+  maxResults?: number;
+  order?: string;
+  videoPublishedAfter?: string;
+  videoPublishedBefore?: string;
+  channelMinSubscribers?: number;
+  channelMaxSubscribers?: number;
+  channelLastUploadAfter?: string;
+  channelLastUploadBefore?: string;
+  creatorOnly?: boolean;
+  sortBy?: 'relevance' | 'subscribers_asc' | 'subscribers_desc' | 'indie_priority' | 'recent_activity';
+  sampleVideosPerChannel?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add quota-aware multi-key YouTube API client fallback and richer creator/channel discovery endpoints
- add HTTP MCP transport with Docker deployment defaults, readiness endpoint, and container-friendly env loading
- add request and tool logging plus channel enrichment metadata for outreach workflows

## Included capabilities
- channels_findCreators one-shot creator discovery
- channel/video search filters for subscriber bands, recent activity, unique channels, and creator heuristics
- normalized channel metadata including latestVideoPublishedAt, country, custom URL, joined date, parsed emails, and contact links
- Docker image defaults to HTTP on port 8088
- detailed MCP and HTTP request logging in container logs

## Verification
- 
pm run build
- docker build -t youtube-mcp-server:latest .
- readiness check on http://127.0.0.1:8088/ready
- live MCP tool call against the running container
