### PR TITLE
fix: log to stderr instead of stdout to prevent STDIO transport corruption

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -81,7 +81,7 @@ function createMcpServer() {
     const channelService = new ChannelService();
 
     server.setRequestHandler(ListToolsRequestSchema, async () => {
-        console.log('[MCP] list_tools requested');
+        console.error('[MCP] list_tools requested');
         return {
             tools: [
                 {
@@ -393,7 +393,7 @@ function createMcpServer() {
         const { name, arguments: args } = request.params;
         const startedAt = Date.now();
 
-        console.log(`[MCP] tool.start name=${name} args=${safeSerialize(args)}`);
+        console.error(`[MCP] tool.start name=${name} args=${safeSerialize(args)}`);
 
         try {
             let result: unknown;
@@ -433,7 +433,7 @@ function createMcpServer() {
                     throw new Error(`Unknown tool: ${name}`);
             }
 
-            console.log(
+            console.error(
                 `[MCP] tool.success name=${name} durationMs=${Date.now() - startedAt} summary=${summarizeResult(result)}`
             );
 
@@ -510,7 +510,7 @@ async function startHttpMcpServer() {
         const url = new URL(req.url || '/', origin);
 
         res.on('finish', () => {
-            console.log(
+            console.error(
                 `[HTTP] ${req.method} ${url.pathname} status=${res.statusCode} durationMs=${Date.now() - requestStartedAt}`
             );
         });
@@ -536,7 +536,7 @@ async function startHttpMcpServer() {
         if (req.method === 'POST') {
             try {
                 parsedBody = await readJsonBody(req);
-                console.log(`[HTTP] request.body method=${req.method} path=${url.pathname} body=${safeSerialize(parsedBody)}`);
+                console.error(`[HTTP] request.body method=${req.method} path=${url.pathname} body=${safeSerialize(parsedBody)}`);
             } catch (error) {
                 writeJson(res, 400, {
                     jsonrpc: '2.0',
@@ -588,10 +588,10 @@ async function startHttpMcpServer() {
         });
     });
 
-    console.log('YouTube MCP Server v1.0.0 started successfully over HTTP');
-    console.log(`Listening on http://${host}:${port}/mcp`);
-    console.log(`Readiness endpoint available at http://${host}:${port}/ready`);
-    console.log('Server will validate YouTube API key when tools are called');
+    console.error('YouTube MCP Server v1.0.0 started successfully over HTTP');
+    console.error(`Listening on http://${host}:${port}/mcp`);
+    console.error(`Readiness endpoint available at http://${host}:${port}/ready`);
+    console.error('Server will validate YouTube API key when tools are called');
 
     return httpServer;
 }


### PR DESCRIPTION
## Problem

Fixes #18.

Per the MCP specification, STDIO transport requires stdout to contain *only* JSON-RPC messages. Any other output corrupts the protocol and the client drops the connection immediately after handshake.

This server currently writes diagnostic lines to stdout via `console.log`, e.g. `[MCP] list_tools requested` and the startup banner `YouTube MCP Server v1.0.0 started successfully`. Clients like Claude Code / Claude Desktop fail with:

```
JSON Parse error: Unexpected identifier "MCP"
Unexpected token 'Y', "YouTube MC"... is not valid JSON
```

Reproducible on every stdio client; HTTP transport is unaffected.

## Fix

Replace every `console.log` in `src/server.ts` with `console.error`. stderr is the MCP-sanctioned channel for diagnostics — no behavioral change for HTTP, fixes stdio.

Nine call sites changed. The HTTP startup banners are switched too, for consistency; they were harmless there but inconsistent.

## Verification

**Before:** `claude mcp list` reports "connected" but `/mcp` shows `youtube · ✘ failed`. Log excerpt:

```
Connection established with capabilities: {"hasTools":true,...}
STDIO connection dropped after 0s uptime
Connection error: JSON Parse error: Unexpected identifier "MCP"
```

**After:** handshake completes, `tools/list` returns all 10 tools, `/mcp` reports `youtube · ✔ connected`, live call to `videos_searchVideos` succeeds.